### PR TITLE
Rescue errors when the postgres adapter isn't in use

### DIFF
--- a/lib/silent-postgres/railtie.rb
+++ b/lib/silent-postgres/railtie.rb
@@ -1,6 +1,8 @@
 module SilentPostgres
   def self.init!
     ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.send(:include, SilentPostgres)
+  rescue NameError
+    Rails.logger.debug "The PostgresSQLAdapter is not in use.  Skipping silencer."
   end
 
   if defined?(Rails::Railtie)


### PR DESCRIPTION
Added protection against environments where the postgres adapter isn't in use
