### PR TITLE
Use alias_method instead of deprecated alias_method_chain

### DIFF
--- a/lib/silent-postgres.rb
+++ b/lib/silent-postgres.rb
@@ -8,7 +8,8 @@ if Rails.env.development? || Rails.env.test?
 
     def self.included(base)
       SILENCED_METHODS.each do |m|
-        base.send :alias_method_chain, m, :silencer
+        base.send :alias_method, "#{m}_without_silencer", m
+        base.send :alias_method, m, "#{m}_with_silencer"
       end
     end
 


### PR DESCRIPTION
Solves this `DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super. (called from <top (required)> at /Users/mikker/Developer/uwb/urbanwinebox/config/environment.rb:6)`.

Thanks!
